### PR TITLE
[fix] refreshable 동작 수정, alarmArray 완전히 삭제후 다시 데이터 채워서 무조건 전부 다시 그리도록 수정

### DIFF
--- a/Zeno/Sources/View/Alarm/AlarmView.swift
+++ b/Zeno/Sources/View/Alarm/AlarmView.swift
@@ -136,7 +136,11 @@ struct AlarmView: View {
                         .refreshable {
                             if let currentUser = userViewModel.currentUser {
                                 Task {
-                                    await alarmViewModel.fetchLastestAlarm(showUserID: currentUser.id)
+                                    if selectedCommunityId.isEmpty {
+                                        await alarmViewModel.fetchAlarmPagenation2(showUserID: currentUser.id)
+                                    } else {
+                                        await alarmViewModel.fetchAlarmPagenation2(showUserID: currentUser.id, communityID: selectedCommunityId)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
# 홈탭에서 간헐적으로 알람을 받고 .refreshable 동작 시 리스트 사이 빈 공간이 생기는 문제 발생

- 원인 : 기존에는 추가 파이어베이스에 데이터 존재 여부에 따라서 fetch 를 실행했지만, 이런 상황에서 데이터가 추가되어 alarmArray 에 append 되었을 때 기존 셀들을 재활용하여 뷰를 그릴 때 문제가 생기는 것으로 추정
- 해결 : 기존 alarmArray 삭제하고 최신 데이터 새로 받아오는 로직으로 변경하여 스크롤뷰 전부 다시 그리도록 수정

이 후 여러 사람과 테스트를 위해 print("refresh") 와 print("======alarmViewModel.loadMoreData") 는 살려둠