### PR TITLE
[수정] 초성확인 버그 수정

### DIFF
--- a/Zeno/Sources/View/Alarm/AlarmInitial/AlarmChangingView.swift
+++ b/Zeno/Sources/View/Alarm/AlarmInitial/AlarmChangingView.swift
@@ -22,6 +22,9 @@ struct AlarmChangingView: View {
     @State private var chosungIndex: Int = 16
     @State private var initialCheckCount: Int = 0
     @State private var resultArray: [Int] = []
+    
+    @State private var isFirstOnAppear: Bool = true
+    
     let selectAlarm: Alarm
     
     let hangul = ["ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"]
@@ -71,8 +74,13 @@ struct AlarmChangingView: View {
                 dismiss()
                 backAlert = false
         })
-        .task {
-            chosung = ChosungCheck(word: selectAlarm.sendUserName)
+        .onAppear {
+            if isFirstOnAppear {
+                chosung = ChosungCheck(word: selectAlarm.sendUserName)
+            }
+        }
+        .onDisappear {
+            isFirstOnAppear = false
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {


### PR DESCRIPTION
- 다른 탭에 나갔다 들어올 때 .task { }를 통해 실행되는 함수가 계속 실행되는 상황 발생.
- 이런 상황을 해결하기 위해 onAppear와 onDisappear를 통해 처음 뷰가 그려질 때 한번만 실행되고 그 이후로는 버튼에 의해서 초성확인 함수가 실행될 수 있게 코드 수정