### PR TITLE
[Fix] 제노 게임 시 빠르게 클릭하면 여러번 통신하는 문제 디바운서 제거하여 해결, zenoList index 관리 수정

### DIFF
--- a/Zeno/Sources/View/Zeno/ZenoView.swift
+++ b/Zeno/Sources/View/Zeno/ZenoView.swift
@@ -75,24 +75,14 @@ struct ZenoView: View {
                                 
                                 /// 버튼을 누를 때 마다 해당 사용자에게 알림이 감
                                 Task {
-                                    if selected == 0 {
+                                    if selected != 0 && zenoList.count >= selected{
                                         if let currentUser = zenoViewModel.currentUser {
-                                            await alarmViewModel.pushAlarm(sendUser: currentUser, receiveUser: user, community: community, zeno: zenoList[selected])
-                                        }
-                                    } else {
-                                        if let currentUser = zenoViewModel.currentUser {
-                                            await alarmViewModel.pushAlarm(sendUser: currentUser, receiveUser: user, community: community, zeno: zenoList[selected-1])
+                                            await alarmViewModel.pushAlarm(sendUser: currentUser, receiveUser: user, community: community, zeno: zenoList[selected - 1])
                                         }
                                     }
                                 }
-                                if selected < 8 {
-                                    debouncer.run {
-                                        selected += 1
-                                        resetUsers()
-                                    }
-                                } else {
-                                    selected += 1
-                                }
+                                selected += 1
+                                resetUsers()
                             } label: {
                                 HStack {
                                     ZenoKFImageView(user)


### PR DESCRIPTION
# problem
빠르게 사람 클릭 시 질문이 안넘어가고 대상자에게 누르는 횟수만큼 푸시알림이 가는 문제

# solution
다음 문제 넘어가는 로직에 디바운서가 설정되어 있었는데 제거함
제노 질문 인덱스 관리 코드 수정